### PR TITLE
feat: optimise for pederson hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "ark-bls12-381"
@@ -318,7 +318,7 @@ dependencies = [
  "env_logger",
  "log",
  "serde",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet-core",
  "starknet-crypto",
  "thiserror",
@@ -362,7 +362,7 @@ dependencies = [
  "blake2",
  "cfg-if",
  "serde",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "sha3",
  "starknet-core",
  "starknet-crypto",
@@ -404,7 +404,7 @@ dependencies = [
  "ark_swiftness_utils",
  "num-traits",
  "serde",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "sha3",
  "starknet-core",
  "starknet-crypto",
@@ -427,6 +427,8 @@ dependencies = [
  "ark_swiftness_field",
  "ark_swiftness_utils",
  "blake2",
+ "lazy_static",
+ "log",
  "num-bigint",
  "num-traits",
  "once_cell",
@@ -474,6 +476,7 @@ dependencies = [
  "ark_swiftness_stark",
  "ark_swiftness_transcript",
  "clap",
+ "log",
  "num-bigint",
  "regex",
  "serde",
@@ -500,7 +503,7 @@ dependencies = [
  "hex",
  "log",
  "serde",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet-core",
  "starknet-crypto",
  "thiserror",
@@ -533,6 +536,8 @@ dependencies = [
  "ark-serialize",
  "ark_swiftness_field",
  "bincode",
+ "env_logger",
+ "log",
  "num-bigint",
  "num-traits",
  "ruint",
@@ -542,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "base64"
@@ -611,9 +616,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "shlex",
 ]
@@ -641,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -651,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -663,14 +668,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -751,7 +756,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -762,7 +767,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -827,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -970,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -988,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-crypto"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb5d4f22241504f7c7b8d2c3a7d7835d7c07117f10bff2a7d96a9ef6ef217c3"
+checksum = "bbc2a4da0d9e52ccfe6306801a112e81a8fc0c76aa3e4449fefeda7fef72bb34"
 dependencies = [
  "lambdaworks-math",
  "serde",
@@ -1000,19 +1005,25 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358e172628e713b80a530a59654154bfc45783a6ed70ea284839800cebdf8f97"
+checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
 dependencies = [
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.158"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -1079,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "paste"
@@ -1112,9 +1123,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -1183,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1195,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1206,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rfc6979"
@@ -1279,7 +1290,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1322,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1332,7 +1343,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.9.0",
+ "serde_with_macros 3.11.0",
  "time",
 ]
 
@@ -1345,19 +1356,19 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1408,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-crypto"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2a821ad8d98c6c3e4d0e5097f3fe6e2ed120ada9d32be87cd1330c7923a2f0"
+checksum = "60a5064173a8e8d2675e67744fd07f310de44573924b6b7af225a6bdd8102913"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -1420,37 +1431,25 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-crypto-codegen",
  "starknet-curve",
  "starknet-types-core",
  "zeroize",
 ]
 
 [[package]]
-name = "starknet-crypto-codegen"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e179dedc3fa6da064e56811d3e05d446aa2f7459e4eb0e3e49378a337235437"
-dependencies = [
- "starknet-curve",
- "starknet-types-core",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "starknet-curve"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56935b306dcf0b8f14bb2a1257164b8478bb8be4801dfae0923f5b266d1b457c"
+checksum = "bcde6bd74269b8161948190ace6cf069ef20ac6e79cd2ba09b320efa7500b6de"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bacf0ba19bc721e518bc4bf389ff13daa8a7c5db5fd320600473b8aa9fcbd"
+checksum = "fa1b9e01ccb217ab6d475c5cda05dbb22c30029f7bb52b192a010a00d77a3d74"
 dependencies = [
  "lambdaworks-crypto",
  "lambdaworks-math",
@@ -1491,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1502,22 +1501,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1578,7 +1577,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1601,9 +1600,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "utf8parse"
@@ -1631,9 +1630,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1642,24 +1641,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1667,22 +1666,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "windows-core"
@@ -1784,7 +1783,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1804,5 +1803,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ env_logger = { version = "0.11.5"}
 chrono = "0.4"
 jemallocator = "0.5"
 hex = "0.4.3"
+lazy_static = "1.5.0"
 [profile.release]
 overflow-checks = true
 

--- a/air/src/layout/dex/mod.rs
+++ b/air/src/layout/dex/mod.rs
@@ -312,7 +312,7 @@ impl<F: SimpleField + PoseidonHash> LayoutTrait<F> for Layout {
             .log_n_steps
             .assert_lt(&F::from_stark_felt(MAX_LOG_N_STEPS));
 
-        let n_steps = F::two().powers_felt(&public_input.log_n_steps);
+        let _n_steps = F::two().powers_felt(&public_input.log_n_steps);
         let trace_length = stark_domains.trace_domain_size.clone();
         // TODO: enable check
         // ensure!(

--- a/air/src/layout/recursive/mod.rs
+++ b/air/src/layout/recursive/mod.rs
@@ -310,7 +310,7 @@ impl<F: SimpleField + PoseidonHash> LayoutTrait<F> for Layout {
             .log_n_steps
             .assert_lt(&F::from_stark_felt(MAX_LOG_N_STEPS));
 
-        let n_steps = F::two().powers_felt(&public_input.log_n_steps);
+        let _n_steps = F::two().powers_felt(&public_input.log_n_steps);
         let trace_length = stark_domains.trace_domain_size.clone();
         // TODO: enable check
         // ensure!(

--- a/air/src/layout/recursive_with_poseidon/mod.rs
+++ b/air/src/layout/recursive_with_poseidon/mod.rs
@@ -351,7 +351,7 @@ impl<F: SimpleField + PoseidonHash> LayoutTrait<F> for Layout {
             .log_n_steps
             .assert_lt(&F::from_stark_felt(MAX_LOG_N_STEPS));
 
-        let n_steps = F::two().powers_felt(&public_input.log_n_steps);
+        let _n_steps = F::two().powers_felt(&public_input.log_n_steps);
         let trace_length = stark_domains.trace_domain_size.clone();
         // TODO: enable check
         // ensure!(

--- a/air/src/layout/small/mod.rs
+++ b/air/src/layout/small/mod.rs
@@ -312,7 +312,7 @@ impl<F: SimpleField + PoseidonHash> LayoutTrait<F> for Layout {
             .log_n_steps
             .assert_lt(&F::from_stark_felt(MAX_LOG_N_STEPS));
 
-        let n_steps = F::two().powers_felt(&public_input.log_n_steps);
+        let _n_steps = F::two().powers_felt(&public_input.log_n_steps);
         let trace_length = stark_domains.trace_domain_size.clone();
         // TODO: enable check
         // ensure!(

--- a/air/src/layout/starknet/mod.rs
+++ b/air/src/layout/starknet/mod.rs
@@ -406,7 +406,7 @@ impl<F: SimpleField + PoseidonHash> LayoutTrait<F> for Layout {
             .log_n_steps
             .assert_lt(&F::from_stark_felt(MAX_LOG_N_STEPS));
 
-        let n_steps = F::two().powers_felt(&public_input.log_n_steps);
+        let _n_steps = F::two().powers_felt(&public_input.log_n_steps);
         let trace_length = stark_domains.trace_domain_size.clone();
         // TODO: enable check
         // ensure!(

--- a/air/src/layout/starknet_with_keccak/autogenerated.rs
+++ b/air/src/layout/starknet_with_keccak/autogenerated.rs
@@ -4,7 +4,7 @@ use crate::layout::starknet_with_keccak::const_relations::{
     init_pow_relation_for_eval_oods_polynomial_inner,
 };
 use crate::layout::LayoutTrait;
-use log::{debug, info, trace};
+use log::{debug, trace};
 use starknet_crypto::Felt;
 use std::collections::HashMap;
 use swiftness_field::SimpleField;
@@ -30,7 +30,6 @@ pub fn eval_composition_polynomial_inner<F: SimpleField + PoseidonHash>(
 ) -> F {
     println!("enter eval_composition_polynomial_inner");
     trace!("enter eval_composition_polynomial_inner");
-    let current = std::time::Instant::now();
     // Compute powers.
     let pow0 = point.powers_felt(&global_values.trace_length.rsh(19));
     let pow1 = point.powers_felt(&global_values.trace_length.rsh(15));
@@ -4317,7 +4316,10 @@ pub fn eval_composition_polynomial_inner<F: SimpleField + PoseidonHash>(
         .field_div(&(domain14));
     total_sum += constraint_coefficients[346].clone() * &value;
     // trace!("file{}, line{}", file!(), line!());
-    debug!("eval_composition_polynomial_inner, used time: {:?}", current.elapsed());
+    debug!(
+        "eval_composition_polynomial_inner, used time: {:?}",
+        current.elapsed()
+    );
     total_sum
 }
 
@@ -4330,7 +4332,6 @@ pub fn eval_oods_polynomial_inner<F: SimpleField + PoseidonHash, Layout: LayoutT
     trace_generator: &F,
 ) -> F {
     trace!("enter eval odds polynomial");
-    let current = std::time::Instant::now();
     // Compute powers.
     let pow0 = trace_generator.powers([0_u64]);
     let pow1 = trace_generator.powers([446471_u64]);
@@ -4742,7 +4743,10 @@ pub fn eval_oods_polynomial_inner<F: SimpleField + PoseidonHash, Layout: LayoutT
         - &oods_values[735])
         .field_div(&(point.clone() - oods_point_to_deg));
     total_sum += constraint_coefficients[735].clone() * &value;
-    debug!("exit eval_oods_polynomial_inner, used {}", current.elapsed().as_secs_f32());
+    debug!(
+        "exit eval_oods_polynomial_inner, used {}",
+        current.elapsed().as_secs_f32()
+    );
     total_sum
 }
 

--- a/air/src/layout/starknet_with_keccak/mod.rs
+++ b/air/src/layout/starknet_with_keccak/mod.rs
@@ -445,7 +445,7 @@ impl<F: SimpleField + PoseidonHash> LayoutTrait<F> for Layout {
             .log_n_steps
             .assert_lt(&F::from_stark_felt(MAX_LOG_N_STEPS));
 
-        let n_steps = F::two().powers_felt(&public_input.log_n_steps);
+        let _n_steps = F::two().powers_felt(&public_input.log_n_steps);
         let trace_length = stark_domains.trace_domain_size.clone();
         // TODO: enable check
         // ensure!(

--- a/air/src/public_memory.rs
+++ b/air/src/public_memory.rs
@@ -116,10 +116,14 @@ impl<F: SimpleField + PoseidonHash> PublicInput<F> {
         debug!("self.main_page.len() = {}", self.main_page.len());
         let current = std::time::Instant::now();
         for memory in self.main_page.iter() {
-            main_page_hash = PedersenHash::hash(main_page_hash.clone(), memory.address.clone());
-            main_page_hash = PedersenHash::hash(main_page_hash.clone(), memory.value.clone());
+            let memory = memory.clone();
+            main_page_hash = PedersenHash::hash(main_page_hash, memory.address);
+            main_page_hash = PedersenHash::hash(main_page_hash, memory.value);
         }
-        debug!("Main page hash computed in {} seconds", current.elapsed().as_secs_f32());
+        debug!(
+            "Main page hash computed in {} seconds",
+            current.elapsed().as_secs_f32()
+        );
         main_page_hash = PedersenHash::hash(
             main_page_hash,
             F::two() * F::from_constant(self.main_page.len() as u128),

--- a/air/src/trace/config.rs
+++ b/air/src/trace/config.rs
@@ -1,9 +1,9 @@
 use crate::layout::LayoutTrait;
 use serde::{Deserialize, Serialize};
-use starknet_crypto::Felt;
+// use starknet_crypto::Felt;
 use swiftness_commitment::vector;
 
-const MAX_N_COLUMNS: Felt = Felt::from_hex_unchecked("0x80");
+//const MAX_N_COLUMNS: Felt = Felt::from_hex_unchecked("0x80");
 
 // Configuration for the Traces component.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/air/src/types.rs
+++ b/air/src/types.rs
@@ -23,7 +23,7 @@ pub struct SegmentInfo<F: SimpleField + PoseidonHash> {
 }
 
 #[serde_as]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct AddrValue<F: SimpleField + PoseidonHash> {
     #[cfg_attr(
         feature = "std",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,8 @@ use log::{debug, error, info, trace, warn};
 // use std::env;
 // use std::io::Write;
 use std::path::PathBuf;
+use std::thread;
+use std::time::{Duration, Instant};
 #[cfg(feature = "dex")]
 use swiftness_air::layout::dex::Layout;
 #[cfg(feature = "recursive")]
@@ -38,30 +40,29 @@ struct CairoVMVerifier {
 
 fn init_logger() {
     env_logger::init();
-    // let mut builder = Builder::from_default_env();
-    // builder.format(|buf, record| {
-    //     let now = Local::now();
-    //     let datetime = now.format("%Y-%m-%d %H:%M:%S");
-    //     writeln!(
-    //         buf,
-    //         "{} [{}] ({}:{}) : {}",
-    //         datetime,
-    //         record.level(),
-    //         record.file().unwrap_or("unknown"),
-    //         record.line().unwrap_or(0),
-    //         record.args()
-    //     )
-    // });
-    //
-    // builder.init();
     error!("test error");
     warn!("test warn");
     info!("test info");
     debug!("test debug");
     trace!("test trace");
 }
+fn init_memory_logger() {
+    let start_time = Instant::now();
+
+    thread::spawn(move || loop {
+        if start_time.elapsed() >= Duration::from_secs(600) {
+            println!("Memory logger stopped after 10 minutes.");
+            break;
+        }
+
+        swiftness_utils::mem_tools::print_memory_usage();
+
+        thread::sleep(Duration::from_secs(1));
+    });
+}
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_logger();
+    init_memory_logger();
     info!("Parsing proof from file");
     let cli = CairoVMVerifier::parse();
     let stark_proof = parse(std::fs::read_to_string(cli.proof)?)?;

--- a/commitment/src/vector/decommit.rs
+++ b/commitment/src/vector/decommit.rs
@@ -127,7 +127,7 @@ fn hash_friendly_unfriendly<F: SimpleField + PoseidonHash + KeccakHash + Blake2s
 ) -> F {
     F::select(
         &is_verifier_friendly,
-        { PoseidonHash::hash(x.clone(), y.clone()) },
+        PoseidonHash::hash(x.clone(), y.clone()),
         {
             let mut hash_data = Vec::with_capacity(64);
             hash_data.extend(x.to_be_bytes());

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -2,11 +2,11 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-const MAX_LAST_LAYER_LOG_DEGREE_BOUND: u64 = 15;
-const MAX_FRI_LAYERS: u64 = 15;
-const MIN_FRI_LAYERS: u64 = 2;
-const MAX_FRI_STEP: u64 = 4;
-const MIN_FRI_STEP: u64 = 1;
+// const MAX_LAST_LAYER_LOG_DEGREE_BOUND: u64 = 15;
+// const MAX_FRI_LAYERS: u64 = 15;
+// const MIN_FRI_LAYERS: u64 = 2;
+// const MAX_FRI_STEP: u64 = 4;
+// const MIN_FRI_STEP: u64 = 1;
 
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/hash/Cargo.toml
+++ b/hash/Cargo.toml
@@ -26,7 +26,8 @@ once_cell = { workspace = true }
 ark-bls12-381 = { workspace = true }
 blake2 = { workspace = true }
 sha3 = { workspace = true }
-
+lazy_static = { workspace = true }
+log = { workspace = true }
 [dev-dependencies]
 ark-poly = { workspace = true }
 ark-relations = { workspace = true }

--- a/hash/src/keccak/mod.rs
+++ b/hash/src/keccak/mod.rs
@@ -1,21 +1,14 @@
 mod constants;
 mod periodic;
 mod utils;
-use ark_bls12_381::{Bls12_381, Fr};
-use ark_ff::UniformRand;
 use ark_r1cs_std::boolean::Boolean;
-use ark_r1cs_std::eq::EqGadget;
 use ark_r1cs_std::uint64::UInt64;
-use ark_r1cs_std::{R1CSVar, ToBitsGadget};
-use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
-use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use ark_std::ops::{BitAnd, BitXor, Not};
-use ark_std::rand::{thread_rng, Rng};
+use ark_r1cs_std::{ToBitsGadget};
+use ark_relations::r1cs::{SynthesisError};
 use constants::{ROTR, ROUND_CONSTANTS};
 
 use crate::keccak::utils::{bitand, not, rotate_left};
 use ark_ff::PrimeField;
-use ark_r1cs_std::alloc::AllocVar;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_r1cs_std::uint8::UInt8;
 use sha3::Digest;

--- a/hash/src/keccak/utils.rs
+++ b/hash/src/keccak/utils.rs
@@ -35,21 +35,21 @@ pub fn bitand<F: PrimeField>(a: &UInt64<F>, b: &UInt64<F>) -> UInt64<F> {
     UInt64::from_bits_le(&and_bits)
 }
 
-fn from_bits_to_u8(bools: &[bool]) -> u8 {
-    assert_eq!(bools.len(), 8);
-    let mut result: u8 = 0;
-    let mut shift = 0;
-    for &bit in bools {
-        if bit {
-            result |= 1 << shift;
-        }
-        shift += 1;
-        if shift == 8 {
-            break;
-        }
-    }
-    result
-}
+// fn from_bits_to_u8(bools: &[bool]) -> u8 {
+//     assert_eq!(bools.len(), 8);
+//     let mut result: u8 = 0;
+//     let mut shift = 0;
+//     for &bit in bools {
+//         if bit {
+//             result |= 1 << shift;
+//         }
+//         shift += 1;
+//         if shift == 8 {
+//             break;
+//         }
+//     }
+//     result
+// }
 
 #[cfg(test)]
 mod tests {

--- a/hash/src/pedersen/utils.rs
+++ b/hash/src/pedersen/utils.rs
@@ -1,0 +1,146 @@
+use crate::pedersen::constants::{P0, P1, P2, P3, P4};
+use ark_ec::short_weierstrass::SWCurveConfig;
+use ark_ec::CurveConfig;
+use ark_ff::{Field, PrimeField};
+use ark_r1cs_std::fields::fp::FpVar;
+use ark_r1cs_std::fields::FieldVar;
+use ark_r1cs_std::groups::curves::short_weierstrass::ProjectiveVar;
+use swiftness_field::{Fp, SimpleField};
+use swiftness_utils::curve::StarkwareCurve;
+
+/*
+   Example of code with macro expansion
+   ```rust
+       fn get_a_p0_proj() -> ProjectiveVar<Self, FpVar<<Self as CurveConfig>::BaseField>>
+   where
+       Self: SWCurveConfig,
+       Self::BaseField: PrimeField + SimpleField,
+       <Self::BaseField as Field>::BasePrimeField: SimpleField,
+       FpVar<Self::BaseField>: FieldVar<Self::BaseField, <Self::BaseField as Field>::BasePrimeField> + SimpleField,
+   ;
+   ```
+*/
+macro_rules! define_projective_fn_header {
+    ($fn_name:ident) => {
+        fn $fn_name() -> ProjectiveVar<Self, FpVar<<Self as CurveConfig>::BaseField>>
+        where
+            Self: SWCurveConfig,
+            Self::BaseField: PrimeField + SimpleField,
+            <Self::BaseField as Field>::BasePrimeField: SimpleField,
+            FpVar<Self::BaseField>:
+                FieldVar<Self::BaseField, <Self::BaseField as Field>::BasePrimeField> + SimpleField;
+    };
+}
+
+pub trait CurveProjectiveProvider: SWCurveConfig {
+    define_projective_fn_header!(get_a_p0_proj);
+    define_projective_fn_header!(get_a_p1_proj);
+    define_projective_fn_header!(get_a_p2_proj);
+    define_projective_fn_header!(get_b_p1_proj);
+    define_projective_fn_header!(get_b_p2_proj);
+}
+
+/*
+   Example of code with macro expansion:
+   ```rust
+   thread_local! {
+   static A_P0_PROJ: ProjectiveVar<StarkwareCurve, FpVar<Fp>> =
+       ProjectiveVar::<StarkwareCurve, FpVar<Fp>>::new(
+           FpVar::Constant(SimpleField::from_felt(P0.x)),
+           FpVar::Constant(SimpleField::from_felt(P0.y)),
+           FpVar::Constant(SimpleField::one()),
+       );
+
+       }
+    ```
+*/
+macro_rules! define_projective_vars {
+    ( $( $name:ident, $px:expr, $py:expr ),* ) => {
+        thread_local! {
+            $(
+                static $name: ProjectiveVar<StarkwareCurve, FpVar<Fp>> = {
+                    ProjectiveVar::<StarkwareCurve, FpVar<Fp>>::new(
+                        FpVar::Constant(SimpleField::from_felt($px)),
+                        FpVar::Constant(SimpleField::from_felt($py)),
+                        FpVar::Constant(SimpleField::one()),
+                    )
+                };
+            )*
+        }
+    };
+}
+define_projective_vars!(
+    A_P0_PROJ, P0.x, P0.y, A_P1_PROJ, P1.x, P1.y, A_P2_PROJ, P2.x, P2.y, B_P1_PROJ, P3.x, P3.y,
+    B_P2_PROJ, P4.x, P4.y
+);
+/*
+   Example of code with macro expansion:
+   ```rust
+       fn get_a_p1_proj() -> ProjectiveVar<Self, FpVar<<Self as CurveConfig>::BaseField>>
+   where
+       Self: SWCurveConfig,
+       Self::BaseField: PrimeField + SimpleField,
+       <Self::BaseField as Field>::BasePrimeField: SimpleField,
+       FpVar<Self::BaseField>: FieldVar<Self::BaseField, <Self::BaseField as Field>::BasePrimeField> + SimpleField
+   {
+       A_P1_PROJ.with(|a| a.clone())
+   }
+   ```
+*/
+macro_rules! define_projective_fn {
+    ($fn_name:ident, $proj:ident) => {
+        fn $fn_name() -> ProjectiveVar<Self, FpVar<Self::BaseField>>
+        where
+            Self: SWCurveConfig,
+            Self::BaseField: PrimeField + SimpleField,
+            <Self::BaseField as Field>::BasePrimeField: SimpleField,
+            FpVar<Self::BaseField>:
+                FieldVar<Self::BaseField, <Self::BaseField as Field>::BasePrimeField> + SimpleField,
+        {
+            $proj.with(|a| a.clone())
+        }
+    };
+}
+impl CurveProjectiveProvider for StarkwareCurve {
+    define_projective_fn!(get_a_p0_proj, A_P0_PROJ);
+    define_projective_fn!(get_a_p1_proj, A_P1_PROJ);
+    define_projective_fn!(get_a_p2_proj, A_P2_PROJ);
+    define_projective_fn!(get_b_p1_proj, B_P1_PROJ);
+    define_projective_fn!(get_b_p2_proj, B_P2_PROJ);
+}
+
+/*
+    Example of code with macro expansion:
+    ```rust
+
+
+pub fn get_a_p0_proj_outer<P: SWCurveConfig + CurveProjectiveProvider>() -> ProjectiveVar::<P, FpVar<P::BaseField>>
+where P::BaseField: PrimeField + SimpleField,
+      <P::BaseField as Field>::BasePrimeField: SimpleField,
+      FpVar<P::BaseField>: FieldVar<P::BaseField,
+          <P::BaseField as Field>::BasePrimeField> + SimpleField,
+{
+    CurveProjectiveProvider::get_a_p0_proj()
+}
+
+```
+ */
+macro_rules! define_proj_outer_fn {
+    ($fn_name:ident, $inner_fn:ident) => {
+        pub fn $fn_name<P: SWCurveConfig + CurveProjectiveProvider>(
+        ) -> ProjectiveVar<P, FpVar<P::BaseField>>
+        where
+            P::BaseField: PrimeField + SimpleField,
+            <P::BaseField as Field>::BasePrimeField: SimpleField,
+            FpVar<P::BaseField>:
+                FieldVar<P::BaseField, <P::BaseField as Field>::BasePrimeField> + SimpleField,
+        {
+            CurveProjectiveProvider::$inner_fn()
+        }
+    };
+}
+define_proj_outer_fn!(get_a_p0_proj_outer, get_a_p0_proj);
+define_proj_outer_fn!(get_a_p1_proj_outer, get_a_p1_proj);
+define_proj_outer_fn!(get_a_p2_proj_outer, get_a_p2_proj);
+define_proj_outer_fn!(get_b_p1_proj_outer, get_b_p1_proj);
+define_proj_outer_fn!(get_b_p2_proj_outer, get_b_p2_proj);

--- a/proof_parser/Cargo.toml
+++ b/proof_parser/Cargo.toml
@@ -49,3 +49,4 @@ swiftness_stark = { workspace = true }
 swiftness_transcript = { workspace = true }
 swiftness_field = { workspace = true }
 swiftness_hash = { workspace = true }
+log = "0.4.22"

--- a/proof_parser/src/lib.rs
+++ b/proof_parser/src/lib.rs
@@ -15,6 +15,7 @@ extern crate serde;
 use ark_ff::PrimeField;
 use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar};
 use ark_relations::r1cs::ConstraintSystem;
+use log::info;
 use swiftness_field::SimpleField;
 use swiftness_hash::poseidon::PoseidonHash;
 use swiftness_stark::types::StarkProof as StarkProofVerifier;
@@ -30,7 +31,7 @@ where
     let cs = ConstraintSystem::<F>::new_ref();
     let stark_proof_verifier: StarkProofVerifier<FpVar<F>> =
         StarkProofVerifier::<FpVar<F>>::new_witness(cs.clone(), || Ok(stark_proof)).unwrap();
-    println!("num_constraints={}", cs.num_constraints());
+    info!("num_constraints={}", cs.num_constraints());
     assert!(cs.is_satisfied().unwrap());
     Ok(stark_proof_verifier)
 }

--- a/stark/src/stark.rs
+++ b/stark/src/stark.rs
@@ -30,11 +30,17 @@ impl<F: SimpleField + PoseidonHash + Blake2sHash + KeccakHash> StarkProof<F> {
         Layout::validate_public_input(&self.public_input, &stark_domains)?;
 
         info!("Computing initial hash seed for Fiat-Shamir transcript");
-        let current = std::time::Instant::now();
+        let _current = std::time::Instant::now();
         // Compute the initial hash seed for the Fiat-Shamir transcript.
-        let digest = self.public_input.get_hash();
-        debug!("Initial hash seed computed in {} seconds", current.elapsed().as_secs_f32());
-        debug!("public_input_hash={}", hex::encode(digest.get_value().into_bigint().to_bytes_le()));
+        let digest = self.public_input.get_hash(); 
+        debug!(
+            "Initial hash seed computed in {} seconds",
+            _current.elapsed().as_secs_f32()
+        );
+        debug!(
+            "public_input_hash={}",
+            hex::encode(digest.get_value().into_bigint().to_bytes_le())
+        );
         // Construct the transcript.
         // TODO: is this correct?
         let mut transcript = Transcript::new(digest);
@@ -68,7 +74,10 @@ impl<F: SimpleField + PoseidonHash + Blake2sHash + KeccakHash> StarkProof<F> {
             &self.witness,
             &stark_domains,
         )?;
-        info!("Proof verified in {} seconds", current.elapsed().as_secs_f32());
+        info!(
+            "Proof verified in {} seconds",
+            current.elapsed().as_secs_f32()
+        );
 
         info!("verifying public input ");
         Ok(Layout::verify_public_input(&self.public_input)?)

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,6 +20,8 @@ bincode = { workspace = true }
 serde_json = { workspace = true }
 num-traits = { workspace = true }
 ark-r1cs-std = { workspace = true }
+log = {workspace = true}
+env_logger = {workspace = true}
 
 [dev-dependencies]
 ark-relations = { workspace = true }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,4 +1,7 @@
 #![feature(buf_read_has_data_left, int_roundings)]
+
+pub mod mem_tools;
+
 use ark_ff::FftField;
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::EvaluationDomain;

--- a/utils/src/mem_tools.rs
+++ b/utils/src/mem_tools.rs
@@ -1,0 +1,45 @@
+use log::{trace};
+use std::fmt::Display;
+use std::fs::File;
+use std::io::Read;
+struct StatM {
+    size: u64,
+    resident: u64,
+    share: u64,
+    text: u64,
+    lib: u64,
+    data: u64,
+    dt: u64,
+}
+impl From<String> for StatM {
+    fn from(s: String) -> Self {
+        let mut parts = s.split_whitespace();
+        Self {
+            size: parts.next().unwrap().parse().unwrap(),
+            resident: parts.next().unwrap().parse().unwrap(),
+            share: parts.next().unwrap().parse().unwrap(),
+            text: parts.next().unwrap().parse().unwrap(),
+            lib: parts.next().unwrap().parse().unwrap(),
+            data: parts.next().unwrap().parse().unwrap(),
+            dt: parts.next().unwrap().parse().unwrap(),
+        }
+    }
+}
+impl Display for StatM {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "size={}, resident={}, share={}, text={}, lib={}, data={}, dt={}",
+            self.size, self.resident, self.share, self.text, self.lib, self.data, self.dt
+        )
+    }
+}
+//        info!("Memory usage: size={}, resident={}, share={}, text={}, lib={}, data={}, dt={}",
+pub fn print_memory_usage() {
+    let mut file = File::open("/proc/self/statm").unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .expect("cannot read /proc/self/statm");
+    let statm: StatM = contents.trim().to_string().into();
+    trace!("Memory usage: {}", statm);
+}


### PR DESCRIPTION
## Problem

During testing, we observed that the line `let digest = self.public_input.get_hash();` consumes approximately 60GB of memory and takes around 160 seconds to run. This performance needs optimization.

## Work Done

Analysis showed that most of the time is spent in the function `gen_element_steps_var`, which takes about 150 seconds. We optimized it by:

	1.	Using global variables to replace constants, avoiding redundant calculations.
	2.	Improving bitwise operation efficiency.

## Result

The optimization was successful, reducing memory usage from 60GB to 3GB and execution time from 160 seconds to 27 seconds.